### PR TITLE
Fix path handling

### DIFF
--- a/incs/ft_minishell.h
+++ b/incs/ft_minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_minishell.h                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: alebarbo <alebarbo@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: lseabra- <lseabra-@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/30 01:44:19 by alebarbo          #+#    #+#             */
-/*   Updated: 2025/12/18 16:04:01 by alebarbo         ###   ########.fr       */
+/*   Updated: 2025/12/18 16:36:49 by lseabra-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,6 @@ void	ft_dup2_backup_close(int oldfd, int newfd, t_cmd *cmd);
 void	ft_reset_dup2(t_cmd *cmd);
 void	ft_close_unused_fds(t_cmd *cmd);
 void	ft_close_cmd_files(t_cmd *cmd);
-bool	ft_is_directory(char *path);
 int		ft_resolve_cmd_path(char *cmd, char **ms_envp, char **path_addr);
 void	ft_wait_all_pids(t_data *dt);
 void	ft_cleanup_line(t_data *dt);

--- a/srcs/ft_exec_child.c
+++ b/srcs/ft_exec_child.c
@@ -3,39 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   ft_exec_child.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: alebarbo <alebarbo@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: lseabra- <lseabra-@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/21 13:01:44 by lseabra-          #+#    #+#             */
-/*   Updated: 2025/12/18 16:02:51 by alebarbo         ###   ########.fr       */
+/*   Updated: 2025/12/18 16:45:28 by lseabra-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <ft_minishell.h>
-
-static void	ft_handle_path_failure(t_cmd *cmd, int status)
-{
-	char	*message;
-	char	*target;
-
-	if (cmd && cmd->args && cmd->args[0] && !cmd->args[0][0])
-		target = "\"\"";
-	else if (cmd && cmd->args)
-		target = cmd->args[0];
-	else
-		target = NULL;
-	if (status == EXIT_NOT_FOUND && ft_strchr(cmd->args[0], '/'))
-		message = ERR_NO_FILE_DIR;
-	else if (status == EXIT_NOT_FOUND)
-		message = ERR_CMD_NOT_FOUND;
-	else if (status == EXIT_CANNOT_EXEC && ft_is_directory(cmd->args[0]))
-		message = ERR_IS_DIR;
-	else if (status == EXIT_CANNOT_EXEC)
-		message = ERR_NO_PERMISSION;
-	else
-		message = ERR_GENERIC;
-	ft_puterror(NULL, target, message);
-	ft_get_status(status, true);
-}
 
 static int	ft_exec_cmd(t_cmd *cmd, char **ms_envp)
 {
@@ -46,10 +21,7 @@ static int	ft_exec_cmd(t_cmd *cmd, char **ms_envp)
 	ft_dup2_close(cmd->outfile, STDOUT_FILENO);
 	ft_get_status(ft_resolve_cmd_path(cmd->args[0], ms_envp, &path), true);
 	if (ft_get_status(0, false) != EXIT_SUCCESS)
-	{
-		ft_handle_path_failure(cmd, ft_get_status(0, false));
 		return (ft_get_status(0, false));
-	}
 	execve(path, cmd->args, ms_envp);
 	perror("execve");
 	free(path);

--- a/srcs/ft_resolve_cmd_path.c
+++ b/srcs/ft_resolve_cmd_path.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   ft_resolve_cmd_path.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: alebarbo <alebarbo@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: lseabra- <lseabra-@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/07 12:45:27 by lseabra-          #+#    #+#             */
-/*   Updated: 2025/12/18 16:03:07 by alebarbo         ###   ########.fr       */
+/*   Updated: 2025/12/18 17:08:43 by lseabra-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <ft_minishell.h>
 
-bool	ft_is_directory(char *path)
+static bool	ft_is_directory(char *path)
 {
 	struct stat	path_stat;
 
@@ -29,24 +29,48 @@ bool	ft_is_directory(char *path)
 static int	ft_check_abs_path(char *cmd, char **path_addr)
 {
 	if (ft_is_directory(cmd))
+	{
+		ft_puterror(NULL, cmd, ERR_IS_DIR);
 		return (EXIT_CANNOT_EXEC);
+	}
 	if (access(cmd, F_OK | X_OK) == 0)
 	{
 		*path_addr = ft_strdup(cmd);
 		return (EXIT_SUCCESS);
 	}
 	else if (access(cmd, F_OK) == 0)
+	{
+		ft_puterror(NULL, cmd, ERR_NO_PERMISSION);
 		return (EXIT_CANNOT_EXEC);
+	}
 	else
+	{
+		ft_puterror(NULL, cmd, ERR_NO_FILE_DIR);
 		return (EXIT_NOT_FOUND);
+	}
+}
+
+static char	*ft_build_check_path(char *cmd, char *cur_path, int *status)
+{
+	char	*complete_path;
+
+	complete_path = ft_strjoin(cur_path, "/");
+	complete_path = ft_strjoin_free(complete_path, true, cmd, false);
+	if (access(complete_path, F_OK | X_OK) == 0)
+	{
+		*status = EXIT_SUCCESS;
+		return (complete_path);
+	}
+	else if (access(complete_path, F_OK) == 0 && *status == EXIT_NOT_FOUND)
+		*status = EXIT_CANNOT_EXEC;
+	free(complete_path);
+	return (NULL);
 }
 
 static int	ft_search_in_path(char *cmd, char **path_addr, char **path_arr)
 {
 	int		i;
 	int		status;
-	char	*dir_path;
-	char	*complete_path;
 
 	status = EXIT_NOT_FOUND;
 	if (!cmd || !cmd[0])
@@ -54,19 +78,15 @@ static int	ft_search_in_path(char *cmd, char **path_addr, char **path_arr)
 	i = 0;
 	while (path_arr[i])
 	{
-		dir_path = ft_strjoin(path_arr[i], "/");
-		complete_path = ft_strjoin(dir_path, cmd);
-		free(dir_path);
-		if (access(complete_path, F_OK | X_OK) == 0)
-		{
-			*path_addr = complete_path;
-			return (EXIT_SUCCESS);
-		}
-		else if (access(complete_path, F_OK) == 0 && status == EXIT_NOT_FOUND)
-			status = EXIT_CANNOT_EXEC;
-		free(complete_path);
+		*path_addr = ft_build_check_path(cmd, path_arr[i], &status);
+		if (*path_addr)
+			return (status);
 		i++;
 	}
+	if (status == EXIT_NOT_FOUND)
+		ft_puterror(NULL, cmd, ERR_CMD_NOT_FOUND);
+	else if (status == EXIT_CANNOT_EXEC)
+		ft_puterror(NULL, cmd, ERR_NO_PERMISSION);
 	return (status);
 }
 
@@ -74,10 +94,12 @@ int	ft_resolve_cmd_path(char *cmd, char **ms_envp, char **path_addr)
 {
 	char	**path_arr;
 	int		status;
+	char	*path;
 
-	if (ft_strchr(cmd, '/'))
+	path = ft_getenv("PATH", ms_envp);
+	if (ft_strchr(cmd, '/') || !path)
 		return (ft_check_abs_path(cmd, path_addr));
-	path_arr = ft_split(ft_getenv("PATH", ms_envp), ':');
+	path_arr = ft_split(path, ':');
 	status = ft_search_in_path(cmd, path_addr, path_arr);
 	ft_free_strarr(path_arr);
 	return (status);


### PR DESCRIPTION
**srcs/ft_exec_child.c**
• remove ft_handle_path_failure from logic.
• Modify the ft_exec_cmd to return if status is not EXIT_SUCCESS.

**srcs/ft_resolve_cmd_path.c**
• modify ft_is_directory to static since is just useful in this file.
• ft_check_abs_path prints the proper error right in the moment it is found.
• split ft_search in path in two to comply with the norm.
∘ create ft_build_check_path to build the path, validate it, and return it if it is a valid path.
∘ the ft_build_check modifies the ft_search_in_path status variable throw a pointer.
• in ft_search_in_path, the error is printed in the end depending on the status.
• in ft_resolve_cmd_path has a new var to store the path throw ft_getenv. If path is null, the cmd is treated as a relative path.